### PR TITLE
Fixes #21 typography, correct width, theming

### DIFF
--- a/src/app/mat-select-search/mat-select-search.component.html
+++ b/src/app/mat-select-search/mat-select-search.component.html
@@ -1,8 +1,10 @@
 
 <input matInput class="mat-select-search-input mat-select-search-hidden"/>
 
-<div class="mat-select-search-inner"
-     [ngClass]="{'mat-select-search-inner-multiple': matSelect.multiple}">
+<div
+      #innerSelectSearch
+      class="mat-select-search-inner mat-typography mat-datepicker-content mat-header-row"
+      [ngClass]="{'mat-select-search-inner-multiple': matSelect.multiple}">
   <input matInput
          class="mat-select-search-input"
          autocomplete="off"

--- a/src/app/mat-select-search/mat-select-search.component.scss
+++ b/src/app/mat-select-search/mat-select-search.component.scss
@@ -16,13 +16,13 @@ $multiple-check-width: 33px;
 .mat-select-search-inner {
   position: absolute;
   top: 0;
-  width: calc(100% + #{2 * $mat-menu-side-padding - $scrollbar-width});
-  border-bottom: 1px solid #cccccc;
-  background: white;
+  width: 100%;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
   z-index: 100;
   &.mat-select-search-inner-multiple {
 
-    width: calc(100% + #{2 * $mat-menu-side-padding - $scrollbar-width + $multiple-check-width});
+    width: 100%;
   }
 }
 
@@ -30,14 +30,13 @@ $multiple-check-width: 33px;
   /* allow absolute positioning relative to outer options container */
   transform: none !important;
   max-height: 350px;
-  overflow-x:hidden;
+  overflow-x: hidden;
 }
 
 .mat-select-search-input {
   padding: $mat-menu-side-padding;
   padding-right: $mat-menu-side-padding + $clear-button-width;
   box-sizing: border-box;
-
 }
 .mat-select-search-no-entries-found {
   padding: $mat-menu-side-padding;

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -118,6 +118,9 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, AfterViewIni
   /** Reference to the search input field */
   @ViewChild('searchSelectInput', {read: ElementRef}) searchSelectInput: ElementRef;
 
+  /** Reference to the search input field */
+  @ViewChild('innerSelectSearch', {read: ElementRef}) innerSelectSearch: ElementRef;
+
   /** Current search value */
   get value(): string {
     return this._value;
@@ -204,6 +207,8 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, AfterViewIni
       });
 
     this.initMultipleHandling();
+
+    this.setWidths();
   }
 
   ngOnDestroy() {
@@ -358,6 +363,54 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, AfterViewIni
           this.previousSelectedValues = values;
         }
       });
+  }
+
+  /**
+   *  Set the width of the innerSelectSearch to fit even custom scrollbars
+   *  And support all Operation Systems
+   */
+  private setWidths() {
+    const scrollbarWidth = this.getScrollbarWidth();
+
+    // Constants from scss file
+    const matMenuSidePadding = 16;
+    const multipleCheckWidth = 32;
+
+    const amountToAdd = 2 * matMenuSidePadding - scrollbarWidth;
+    if (!this.matSelect.multiple) {
+      this.innerSelectSearch.nativeElement.style.width = 'calc(100% + ' + amountToAdd + 'px)';
+    } else {
+      this.innerSelectSearch.nativeElement.style.width = 'calc(100% + ' + (amountToAdd + multipleCheckWidth) + 'px)';
+    }
+  }
+
+  /**
+   *  Function to determine the scrollbar width in case of
+   *  custom chrome scrollbars or OS-Differences
+   */
+  private getScrollbarWidth() {
+    const outer = document.createElement('div');
+    outer.style.visibility = 'hidden';
+    outer.style.width = '100px';
+    outer.style.msOverflowStyle = 'scrollbar'; // needed for WinJS apps
+
+    document.body.appendChild(outer);
+
+    const widthNoScroll = outer.offsetWidth;
+    // force scrollbars
+    outer.style.overflow = 'scroll';
+
+    // add innerdiv
+    const inner = document.createElement('div');
+    inner.style.width = '100%';
+    outer.appendChild(inner);
+
+    const widthWithScroll = inner.offsetWidth;
+
+    // remove divs
+    outer.parentNode.removeChild(outer);
+
+    return widthNoScroll - widthWithScroll;
   }
 
   /**


### PR DESCRIPTION
1. Typography was added by using the class 'mat-typography' one the innerSelectSearch-div.

2. The width gets set in the ngOnInit by first calculating the scrollbarWidth with a dummy and then reinitializing the innerSelectSearch-div width. It also take "multiple" in account.

3. This one was a bit tricky. I used Material Classes to inherit the current theme design to support custom theming.