### PR TITLE
Added a new input to indicate whether or not the search field should …

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Furthermore, it provides the following inputs:
 
   /** Label to be shown when no entries are found. Set to null if no message should be shown. */
   @Input() noEntriesFoundLabel = 'Keine Optionen gefunden';
+
+  /** Whether or not the search field should be cleared after the dropdown menu is closed */
+  @Input() clearSearchInput = false;
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ Furthermore, it provides the following inputs:
   /** Label to be shown when no entries are found. Set to null if no message should be shown. */
   @Input() noEntriesFoundLabel = 'Keine Optionen gefunden';
 
-  /** Whether or not the search field should be cleared after the dropdown menu is closed. Useful for server-side filtering. See [#3](https://github.com/bithost-gmbh/ngx-mat-select-search/issues/3) */
+  /** 
+    * Whether or not the search field should be cleared after the dropdown menu is closed. 
+    * Useful for server-side filtering. See [#3](https://github.com/bithost-gmbh/ngx-mat-select-search/issues/3) 
+    */
   @Input() clearSearchInput = false;
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Furthermore, it provides the following inputs:
   /** Label to be shown when no entries are found. Set to null if no message should be shown. */
   @Input() noEntriesFoundLabel = 'Keine Optionen gefunden';
 
-  /** Whether or not the search field should be cleared after the dropdown menu is closed */
+  /** Whether or not the search field should be cleared after the dropdown menu is closed. Useful for server-side filtering. See [#3](https://github.com/bithost-gmbh/ngx-mat-select-search/issues/3) */
   @Input() clearSearchInput = false;
 ```
 

--- a/src/app/mat-select-search/mat-select-search.component.spec.ts
+++ b/src/app/mat-select-search/mat-select-search.component.spec.ts
@@ -311,7 +311,11 @@ describe('MatSelectSearchComponent', () => {
                       .pipe(take(1))
                       .subscribe(() => {
                         fixture.detectChanges();
-                        expect(component.matSelect.options.length).toBe(4);
+                        if (component.matSelectSearch.clearSearchInput) {
+                          expect(component.matSelect.options.length).toBe(4);
+                        } else {
+                          expect(component.matSelect.options.length).toBe(2);
+                        }
 
                         done();
                       });

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -114,7 +114,10 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, AfterViewIni
   /** Label to be shown when no entries are found. Set to null if no message should be shown. */
   @Input() noEntriesFoundLabel = 'Keine Optionen gefunden';
 
-  /** Whether or not the search field should be cleared after the dropdown menu is closed */
+  /** 
+    * Whether or not the search field should be cleared after the dropdown menu is closed. 
+    * Useful for server-side filtering. See [#3](https://github.com/bithost-gmbh/ngx-mat-select-search/issues/3) 
+    */
   @Input() clearSearchInput = true;
 
   /** Reference to the search input field */

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -114,6 +114,9 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, AfterViewIni
   /** Label to be shown when no entries are found. Set to null if no message should be shown. */
   @Input() noEntriesFoundLabel = 'Keine Optionen gefunden';
 
+  /** Whether or not the search field should be cleared after the dropdown menu is closed */
+  @Input() clearSearchInput = true;
+
   /** Reference to the search input field */
   @ViewChild('searchSelectInput', {read: ElementRef}) searchSelectInput: ElementRef;
 
@@ -297,8 +300,10 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, AfterViewIni
     if (!this.searchSelectInput) {
       return;
     }
-    this.searchSelectInput.nativeElement.value = '';
-    this.onInputChange('');
+    if (this.clearSearchInput) {
+      this.searchSelectInput.nativeElement.value = '';
+      this.onInputChange('');
+    }
     if (focus) {
       this._focus();
     }


### PR DESCRIPTION
…be cleared after the dropdown menu is closed.

Like the commit message indicates I added a new input to the MatSelectSearch component so the _reset method can know when to clear the search input field.

This feature is useful when filtering occurs in the server. For example when searching for term returns a list of values that isn't available when the search input is empty.

fixes #3