### PR TITLE
Added a server side filtering example

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -61,4 +61,21 @@
     Selected Bank: {{bankCtrl.value?.name}}
   </p>
   <span class="version-info">Current build: {{version.full}}</span>
+  <h3>Server Side Search</h3>
+  <p>
+    <mat-form-field>
+      <mat-select [formControl]="bankServerSideCtrl" placeholder="Bank">
+        <mat-option disabled="true" class="contains-select-search">
+          <ngx-mat-select-search [formControl]="bankServerSideFilteringCtrl"></ngx-mat-select-search>
+        </mat-option>
+        <mat-option *ngFor="let bank of filteredServerSideBanks | async" [value]="bank">
+          {{bank.name}}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+  </p>
+  <p>
+    Selected Bank: {{bankServerSideCtrl.value?.name}}
+  </p>
+
 </div>

--- a/src/app/mat-select-search/mat-select-search.component.scss
+++ b/src/app/mat-select-search/mat-select-search.component.scss
@@ -54,5 +54,5 @@ $multiple-check-width: 33px;
 }
 /deep/ .cdk-overlay-pane-select-search {
   /* correct offsetY so that the selected option is at the position of the select box when opening */
-  margin-top: -50px;
+  margin-top: 50px; // This won't be required anymore if mat-select-search is inside mat-option.
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -16,3 +16,9 @@ body {
   font-size: 8pt;
   float: right;
 }
+
+.mat-option[aria-disabled=true].contains-select-search {
+  /* let move mat-select-search at the top of the dropdown. As option is disabled, there will be no-ripple hence safe. */
+  position: static;
+  padding: 0;
+}


### PR DESCRIPTION
Challenges in case of server side filtering:
1. No initial options present in case of server side filtering 
2. MatSelect do not open the drowdown when there is no MatOption found.

Solution: use mat-select-search inside disabled mat-option, making it as first option of the dropdown. re-style that mat-option to let mat-select-search sticky at top.

I would suggest mat-select-search should be used inside disabled mat-option as first child. Doing this will no longer require
```
/deep/ .cdk-overlay-pane-select-search {
  /* correct offsetY so that the selected option is at the position of the select box when opening */
  margin-top: 50px; // This won't be required anymore if mat-select-search is inside mat-option.
}
``` 
