### PR TITLE
set black color on mat-select-search-inner div when using inside mat-option

### DIFF
--- a/src/app/mat-select-search/mat-select-search.component.scss
+++ b/src/app/mat-select-search/mat-select-search.component.scss
@@ -5,6 +5,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+ @import '~@angular/material/theming';
+
 $mat-menu-side-padding: 16px !default;
 $clear-button-width: 20px;
 $multiple-check-width: 33px;
@@ -35,7 +37,7 @@ $mat-option-height: 3em;
   &.mat-select-search-inner-multiple {
     width: 100%;
   }
-  
+
   .mat-input-element {
     &:-ms-input-placeholder {
       // fix IE11 not able to focus programmatically with css style -ms-user-select: none
@@ -82,6 +84,9 @@ $mat-option-height: 3em;
   }
   .mat-select-search-clear {
     top: 3px;
+  }
+  > div.mat-select-search-inner {
+    color: $black-87-opacity;
   }
 }
 


### PR DESCRIPTION
When the ngx-mat-select-search component is placed within a `<mat-option/>`, the `matOption` is disabled: https://github.com/bithost-gmbh/ngx-mat-select-search/blob/master/src/app/mat-select-search/mat-select-search.component.ts#L233

Disabling the `matOption` passes the disabled styling to the contents of the `<div class="mat-select-search-inner"/>`, causing text/icons inside to be grey, rather than black.

This commit sets the `div`'s `color` to the default black used by Material's non-disabled inputs (`$black-87-opacity`). 