### PR TITLE
Replace overlayDir.attach in MatSelectSearchComponent

### DIFF
--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -506,23 +506,26 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, AfterViewIni
       overlayClasses.push('cdk-overlay-pane-select-search-with-offset');
     }
 
-    this.matSelect.overlayDir.attach
+    this.matSelect.openedChange
       .pipe(takeUntil(this._onDestroy))
-      .subscribe(() => {
-        // note: this is hacky, but currently there is no better way to do this
-        let element: HTMLElement = this.searchSelectInput.nativeElement;
-        let overlayElement: HTMLElement;
-        while (element = element.parentElement) {
-          if (element.classList.contains('cdk-overlay-pane')) {
-            overlayElement = element;
-            break;
+      .subscribe((opened: boolean) => {
+        if (opened) {
+          // note: this is hacky, but currently there is no better way to do this
+          let element: HTMLElement = this.searchSelectInput.nativeElement;
+          let overlayElement: HTMLElement;
+          while (element = element.parentElement) {
+            if (element.classList.contains('cdk-overlay-pane')) {
+              overlayElement = element;
+              break;
+            }
+          }
+          if (overlayElement) {
+            overlayClasses.forEach(overlayClass => {
+              overlayElement.classList.add(overlayClass);
+            });
           }
         }
-        if (overlayElement) {
-          overlayClasses.forEach(overlayClass => {
-            overlayElement.classList.add(overlayClass);
-          });
-        }
+
       });
 
     this.overlayClassSet = true;

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -26,7 +26,7 @@ import {
 import { ViewportRuler } from '@angular/cdk/scrolling';
 import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { Subject } from 'rxjs';
-import { delay, take, takeUntil } from 'rxjs/operators';
+import { delay, take, takeUntil, filter } from 'rxjs/operators';
 
 import { MatSelectSearchClearDirective } from './mat-select-search-clear.directive';
 
@@ -507,25 +507,25 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, AfterViewIni
     }
 
     this.matSelect.openedChange
-      .pipe(takeUntil(this._onDestroy))
-      .subscribe((opened: boolean) => {
-        if (opened) {
-          // note: this is hacky, but currently there is no better way to do this
-          let element: HTMLElement = this.searchSelectInput.nativeElement;
-          let overlayElement: HTMLElement;
-          while (element = element.parentElement) {
-            if (element.classList.contains('cdk-overlay-pane')) {
-              overlayElement = element;
-              break;
-            }
-          }
-          if (overlayElement) {
-            overlayClasses.forEach(overlayClass => {
-              overlayElement.classList.add(overlayClass);
-            });
+      .pipe(
+        filter(opened => opened)
+        takeUntil(this._onDestroy)
+      )
+      .subscribe(() => {
+        // note: this is hacky, but currently there is no better way to do this
+        let element: HTMLElement = this.searchSelectInput.nativeElement;
+        let overlayElement: HTMLElement;
+        while (element = element.parentElement) {
+          if (element.classList.contains('cdk-overlay-pane')) {
+            overlayElement = element;
+            break;
           }
         }
-
+        if (overlayElement) {
+          overlayClasses.forEach(overlayClass => {
+            overlayElement.classList.add(overlayClass);
+          });
+        }
       });
 
     this.overlayClassSet = true;

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -508,7 +508,7 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, AfterViewIni
 
     this.matSelect.openedChange
       .pipe(
-        filter(opened => opened)
+        filter(opened => opened),
         takeUntil(this._onDestroy)
       )
       .subscribe(() => {


### PR DESCRIPTION
Replace overlayDir.attach in MatSelectSearchComponent with openedChange due deprecation in Angular 10.

fixes https://github.com/bithost-gmbh/ngx-mat-select-search/issues/208