### PR TITLE
fix selection of different instances of same object when using `multiple`

### DIFF
--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -550,8 +550,8 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, AfterViewIni
             }
             const optionValues = this.matSelect.options.map(option => option.value);
             this.previousSelectedValues.forEach(previousValue => {
-              if (!values.find(v => this.matSelect.compareWith(v, previousValue))
-                && !optionValues.find(v => this.matSelect.compareWith(v, previousValue))) {
+              if (!values.some(v => this.matSelect.compareWith(v, previousValue))
+                && !optionValues.some(v => this.matSelect.compareWith(v, previousValue))) {
                 // if a value that was selected before is deselected and not found in the options, it was deselected
                 // due to the filtering, so we restore it.
                 values.push(previousValue);

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -550,7 +550,8 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, AfterViewIni
             }
             const optionValues = this.matSelect.options.map(option => option.value);
             this.previousSelectedValues.forEach(previousValue => {
-              if (values.indexOf(previousValue) === -1 && optionValues.indexOf(previousValue) === -1) {
+              if (!values.find(v => this.matSelect.compareWith(v, previousValue))
+                && !optionValues.find(v => this.matSelect.compareWith(v, previousValue))) {
                 // if a value that was selected before is deselected and not found in the options, it was deselected
                 // due to the filtering, so we restore it.
                 values.push(previousValue);


### PR DESCRIPTION
Fix #215 