### PR TITLE
add option to clear input field on pressing escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ Furthermore, it provides the following inputs:
   /** Disables initial focusing of the input field */
   @Input() disableInitialFocus = false;
 
+  /** Enable clear input on escape pressed */
+  @Input() enableClearOnEscapePressed = false;
+
   /**
    * Prevents home / end key being propagated to mat-select,
    * allowing to move the cursor within the search input instead of navigating the options

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -150,6 +150,9 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, AfterViewIni
   /** Disables initial focusing of the input field */
   @Input() disableInitialFocus = false;
 
+  /** Enable clear input on escape pressed */
+  @Input() enableClearOnEscapePressed = false;
+
   /**
    * Prevents home / end key being propagated to mat-select,
    * allowing to move the cursor within the search input instead of navigating the options
@@ -387,7 +390,7 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, AfterViewIni
     }
 
     // Special case if click Escape, if input is empty, close the dropdown, if not, empty out the search field
-    if (event.keyCode === ESCAPE && this.value) {
+    if (this.enableClearOnEscapePressed === true && event.keyCode === ESCAPE && this.value) {
       this._reset(true);
       event.stopPropagation();
     }

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -21,7 +21,7 @@ import {
   Z,
   ZERO,
   NINE,
-  SPACE, END, HOME, UP_ARROW, DOWN_ARROW,
+  SPACE, END, HOME, UP_ARROW, DOWN_ARROW, ESCAPE,
 } from '@angular/cdk/keycodes';
 import { ViewportRuler } from '@angular/cdk/scrolling';
 import { LiveAnnouncer } from '@angular/cdk/a11y';
@@ -187,7 +187,7 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, AfterViewIni
   @ViewChild('innerSelectSearch', { read: ElementRef, static: true }) innerSelectSearch: ElementRef;
 
   /** Reference to custom search input clear icon */
-  @ContentChild(MatSelectSearchClearDirective, {static: false}) clearIcon: MatSelectSearchClearDirective;
+  @ContentChild(MatSelectSearchClearDirective, { static: false }) clearIcon: MatSelectSearchClearDirective;
 
   @HostBinding('class.mat-select-search-inside-mat-option')
   get isInsideMatOption(): boolean {
@@ -200,8 +200,8 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, AfterViewIni
   }
   private _value: string;
 
-  onChange: Function = (_: any) => {};
-  onTouched: Function = (_: any) => {};
+  onChange: Function = (_: any) => { };
+  onTouched: Function = (_: any) => { };
 
   /** Reference to the MatSelect options */
   public _options: QueryList<MatOption>;
@@ -383,6 +383,12 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, AfterViewIni
       (event.keyCode === SPACE)
       || (this.preventHomeEndKeyPropagation && (event.keyCode === HOME || event.keyCode === END))
     ) {
+      event.stopPropagation();
+    }
+
+    // Special case if click Escape, if input is empty, close the dropdown, if not, empty out the search field
+    if (event.keyCode === ESCAPE && this.value) {
+      this._reset(true);
       event.stopPropagation();
     }
   }


### PR DESCRIPTION
Fixes https://github.com/bithost-gmbh/ngx-mat-select-search/issues/231

If you search for something and press ESC it will empty the search input. if search input is empty and you press ESC it fall back to default behaviour