### PR TITLE
Fix infinite scroll selection

### DIFF
--- a/src/app/examples/08-infinite-scroll-example/infinite-scroll-example.component.html
+++ b/src/app/examples/08-infinite-scroll-example/infinite-scroll-example.component.html
@@ -5,7 +5,7 @@
 </p>
 
 <mat-form-field>
-  <mat-select  msInfiniteScroll (infiniteScroll)="getNextBatch()"
+  <mat-select #matSelectInfiniteScroll msInfiniteScroll (infiniteScroll)="getNextBatch()"
     [formControl]="ctrl"
     placeholder="Select Something"
     (valueChange)="onChange($event)">

--- a/src/app/examples/08-infinite-scroll-example/infinite-scroll-example.component.ts
+++ b/src/app/examples/08-infinite-scroll-example/infinite-scroll-example.component.ts
@@ -13,7 +13,7 @@ import { MatSelect } from '@angular/material/select';
   styleUrls: ['./infinite-scroll-example.component.scss']
 })
 export class InfiniteScrollExampleComponent implements OnInit, OnDestroy {
-  @ViewChild("matSelectInfiniteScroll", { static: true } )
+  @ViewChild('matSelectInfiniteScroll', { static: true } )
   infiniteScrollSelect: MatSelect;
 
   // Mocks some sort of backend data source

--- a/src/app/examples/08-infinite-scroll-example/infinite-scroll-example.component.ts
+++ b/src/app/examples/08-infinite-scroll-example/infinite-scroll-example.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { BehaviorSubject, combineLatest, Subject, Subscription } from 'rxjs';
 import { filter, scan, takeUntil } from 'rxjs/operators';
-import { MatSelect } from "@angular/material/select";
+import { MatSelect } from '@angular/material/select';
 
 /**
  * Based upon: https://stackblitz.com/edit/mat-select-search-with-infinity-scroll
@@ -14,7 +14,7 @@ import { MatSelect } from "@angular/material/select";
 })
 export class InfiniteScrollExampleComponent implements OnInit, OnDestroy {
   @ViewChild("matSelectInfiniteScroll", { static: true } )
-  infiniteScrollSelect:MatSelect;
+  infiniteScrollSelect: MatSelect;
 
   // Mocks some sort of backend data source
   mockBankList = Array.from({ length: 1000 }).map((_, i) => `Bank ${i}`);
@@ -61,14 +61,14 @@ export class InfiniteScrollExampleComponent implements OnInit, OnDestroy {
       }
     });
 
-    const searchValueChange$ = this.searchCtrl.valueChanges
-    const selectOpenChange$ = this.infiniteScrollSelect.openedChange
+    const searchValueChange$ = this.searchCtrl.valueChanges;
+    const selectOpenChange$ = this.infiniteScrollSelect.openedChange;
     combineLatest([selectOpenChange$, searchValueChange$])
       .pipe(
-        filter(([isOpen,]) => isOpen === true),
+        filter(([isOpen, _]) => isOpen === true),
         takeUntil(this._onDestroy)
       )
-      .subscribe(([, value]) => this.onSearchChange(value));
+      .subscribe(([_, value]) => this.onSearchChange(value));
 
     this.options$
       .pipe(


### PR DESCRIPTION
This PR fixes an [issue ](https://github.com/bithost-gmbh/ngx-mat-select-search/issues/243) that was mentioned in a [comment ](https://github.com/bithost-gmbh/ngx-mat-select-search/issues/243#issuecomment-666098889) a few days ago.

fixes https://github.com/bithost-gmbh/ngx-mat-select-search/issues/243

With the infinite scroll example it is not possible to select an item beyond option nine. This is caused by calling `onSearchChange` whenever the select closes.