### PR TITLE
fix: in multi select mode after enter the search is not focused (#265)

### DIFF
--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -27,7 +27,7 @@ import { ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR } from '@angular/f
 import { _countGroupLabelsBeforeOption, MatOption } from '@angular/material/core';
 import { MatSelect, SELECT_PANEL_MAX_HEIGHT } from '@angular/material/select';
 import { MatFormField } from '@angular/material/form-field';
-import { A, DOWN_ARROW, END, ESCAPE, HOME, NINE, SPACE, UP_ARROW, Z, ZERO, } from '@angular/cdk/keycodes';
+import { A, DOWN_ARROW, END, ENTER, ESCAPE, HOME, NINE, SPACE, UP_ARROW, Z, ZERO, } from '@angular/cdk/keycodes';
 import { ViewportRuler } from '@angular/cdk/scrolling';
 import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { BehaviorSubject, combineLatest, Observable, of, Subject } from 'rxjs';
@@ -441,7 +441,7 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, ControlValue
       event.stopPropagation();
     }
 
-    if (this.matSelect.multiple && event.key && event.key === 'Enter') {
+    if (this.matSelect.multiple && event.key && event.keyCode === ENTER) {
       // Regain focus after multiselect, so we can further type
       setTimeout(() => this._focus());
     }

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -441,6 +441,11 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, ControlValue
       event.stopPropagation();
     }
 
+    if (this.matSelect.multiple && event.key && event.key === 'Enter') {
+      // Regain focus after multiselect, so we can further type
+      setTimeout(() => this._focus());
+    }
+
     // Special case if click Escape, if input is empty, close the dropdown, if not, empty out the search field
     if (this.enableClearOnEscapePressed === true && event.keyCode === ESCAPE && this.value) {
       this._reset(true);


### PR DESCRIPTION
It turns out that a simple fix for the issue is catching the `Enter` keypress and regaining focus after a small timeout.

fixes #265 