### PR TITLE
fix: values are not correctly restored in multi-selection mode if no initial selection prior to filtering

### DIFF
--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -579,10 +579,10 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, ControlValue
               }
             });
           }
+          this.previousSelectedValues = values;
 
           if (restoreSelectedValues) {
             this.matSelect._onChange(values);
-            this.previousSelectedValues = values;
           }
         }
       });


### PR DESCRIPTION
fixes #270