### PR TITLE
Introduce "alwaysRestoreMissingValues"

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ Furthermore, it provides the following inputs:
   /** Show/Hide the search clear button of the search input */
   @Input() hideClearSearchButton = false;
 
+  /** 
+   * Always restore selected options on selectionChange for mode multi (e.g. for lazy loading/infinity scrolling). 
+   * Defaults to false, so selected options are only restored while filtering is active. 
+   */
+  @Input() alwaysRestoreSelectedOptionsMulti = false;
+
   /**
   *  Text that is appended to the currently active item label announced by screen readers, informing the user of the current index, value and total
   *  options.

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -193,6 +193,9 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, ControlValue
   /** Show/Hide the search clear button of the search input */
   @Input() hideClearSearchButton = false;
 
+  /** Always restore mission values on selectionChange (e.g. because it wasn't available due to lazy loading) */
+  @Input() alwaysRestoreMissingValues = false;
+
   /** Output emitter to send to parent component with the toggle all boolean */
   @Output() toggleAll = new EventEmitter<boolean>();
 
@@ -577,8 +580,8 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, ControlValue
       .subscribe((values) => {
         let restoreSelectedValues = false;
         if (this.matSelect.multiple) {
-          if (this._formControl.value && this._formControl.value.length
-            && this.previousSelectedValues && Array.isArray(this.previousSelectedValues)) {
+          if (this.alwaysRestoreMissingValues || (this._formControl.value && this._formControl.value.length
+            && this.previousSelectedValues && Array.isArray(this.previousSelectedValues))) {
             if (!values || !Array.isArray(values)) {
               values = [];
             }

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -193,7 +193,7 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, ControlValue
   /** Show/Hide the search clear button of the search input */
   @Input() hideClearSearchButton = false;
 
-  /** 
+  /**
    * Always restore selected options on selectionChange for mode multi (e.g. for lazy loading/infinity scrolling).
    * Defaults to false, so selected options are only restored while filtering is active.
    */

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -580,8 +580,8 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, ControlValue
       .subscribe((values) => {
         let restoreSelectedValues = false;
         if (this.matSelect.multiple) {
-          if (this.alwaysRestoreMissingValues || (this._formControl.value && this._formControl.value.length
-            && this.previousSelectedValues && Array.isArray(this.previousSelectedValues))) {
+          if ((this.alwaysRestoreMissingValues || (this._formControl.value && this._formControl.value.length))
+            && this.previousSelectedValues && Array.isArray(this.previousSelectedValues)) {
             if (!values || !Array.isArray(values)) {
               values = [];
             }

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -193,7 +193,10 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, ControlValue
   /** Show/Hide the search clear button of the search input */
   @Input() hideClearSearchButton = false;
 
-  /** Always restore mission values on selectionChange (e.g. because it wasn't available due to lazy loading) */
+  /** 
+   * Always restore selected options on selectionChange for mode multi (e.g. for lazy loading/infinity scrolling). 
+   * Defaults to false, so selected options are only restored while filtering is active. 
+   */
   @Input() alwaysRestoreSelectedOptionsMulti = false;
 
   /** Output emitter to send to parent component with the toggle all boolean */

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -194,8 +194,8 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, ControlValue
   @Input() hideClearSearchButton = false;
 
   /** 
-   * Always restore selected options on selectionChange for mode multi (e.g. for lazy loading/infinity scrolling). 
-   * Defaults to false, so selected options are only restored while filtering is active. 
+   * Always restore selected options on selectionChange for mode multi (e.g. for lazy loading/infinity scrolling).
+   * Defaults to false, so selected options are only restored while filtering is active.
    */
   @Input() alwaysRestoreSelectedOptionsMulti = false;
 

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -583,7 +583,7 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, ControlValue
       .subscribe((values) => {
         let restoreSelectedValues = false;
         if (this.matSelect.multiple) {
-          if ((this.alwaysRestoreMissingValues || (this._formControl.value && this._formControl.value.length))
+          if ((this.alwaysRestoreSelectedOptionsMulti || (this._formControl.value && this._formControl.value.length))
             && this.previousSelectedValues && Array.isArray(this.previousSelectedValues)) {
             if (!values || !Array.isArray(values)) {
               values = [];

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -194,7 +194,7 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, ControlValue
   @Input() hideClearSearchButton = false;
 
   /** Always restore mission values on selectionChange (e.g. because it wasn't available due to lazy loading) */
-  @Input() alwaysRestoreMissingValues = false;
+  @Input() alwaysRestoreSelectedOptionsMulti = false;
 
   /** Output emitter to send to parent component with the toggle all boolean */
   @Output() toggleAll = new EventEmitter<boolean>();


### PR DESCRIPTION
When `alwaysRestoreMissingValues` set to `true` missing options will always be restored on selectionChange.

This is needed if they aren't available at that moment (due to lazy loading e.g., not only filtering).

fixes #320 