### PR TITLE
Fixed naming according to Material Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,20 +199,20 @@ Custom content with the CSS class `mat-select-search-custom-header-content` can 
 </ngx-mat-select-search>
 ```
 
-#### Global options
-Providing the [`MATSELECTSEARCH_GLOBAL_OPTIONS`](src/app/mat-select-search/global-options.ts) 
+#### Global default options
+Providing the [`MAT_SELECTSEARCH_DEFAULT_OPTIONS`](src/app/mat-select-search/default-options.ts) 
 InjectionToken, the default values of several `@Input()` properties can be set globally.
 See the documentation of the corresponding `@Input()` properties of `MatSelectSearchComponent`.
 
 Example:
 ```typescript
-import { MATSELECTSEARCH_GLOBAL_OPTIONS, MatSelectSearchOptions } from 'ngx-mat-select-search';
+import { MAT_SELECTSEARCH_DEFAULT_OPTIONS, MatSelectSearchOptions } from 'ngx-mat-select-search';
 
 @NgModule({
   ...
   providers: [
     {
-      provide: MATSELECTSEARCH_GLOBAL_OPTIONS,
+      provide: MAT_SELECTSEARCH_DEFAULT_OPTIONS,
       useValue: <MatSelectSearchOptions>{
         closeIcon: 'delete',
         noEntriesFoundLabel: 'No options found',

--- a/src/app/mat-select-search/default-options.ts
+++ b/src/app/mat-select-search/default-options.ts
@@ -41,3 +41,10 @@ export const MAT_SELECTSEARCH_DEFAULT_OPTIONS = new InjectionToken<MatSelectSear
 
 /** Global configurable options for MatSelectSearch. */
 export type MatSelectSearchOptions = Readonly<Partial<Pick<MatSelectSearchComponent, ConfigurableDefaultOptions>>>;
+
+/** @deprecated */
+export const configurableGlobalOptions = configurableDefaultOptions;
+/** @deprecated */
+export type ConfigurableGlobalOptions = ConfigurableDefaultOptions;
+/** @deprecated */
+export const MATSELECTSEARCH_GLOBAL_OPTIONS = MAT_SELECTSEARCH_DEFAULT_OPTIONS;

--- a/src/app/mat-select-search/default-options.ts
+++ b/src/app/mat-select-search/default-options.ts
@@ -2,7 +2,7 @@ import { InjectionToken } from '@angular/core';
 import { MatSelectSearchComponent } from './mat-select-search.component';
 
 /** List of inputs of NgxMatSelectSearchComponent that can be configured with a global default. */
-export const configurableGlobalOptions = [
+export const configurableDefaultOptions = [
   'ariaLabel',
   'clearSearchInput',
   'closeIcon',
@@ -18,7 +18,7 @@ export const configurableGlobalOptions = [
   'searching',
 ] as const;
 
-export type ConfigurableGlobalOptions = typeof configurableGlobalOptions[number];
+export type ConfigurableDefaultOptions = typeof configurableDefaultOptions[number];
 
 /**
  * InjectionToken that can be used to specify global options. e.g.
@@ -26,7 +26,7 @@ export type ConfigurableGlobalOptions = typeof configurableGlobalOptions[number]
  * ```typescript
  * providers: [
  *   {
- *     provide: MATSELECTSEARCH_GLOBAL_OPTIONS,
+ *     provide: MAT_SELECTSEARCH_DEFAULT_OPTIONS,
  *     useValue: <MatSelectSearchOptions>{
  *       closeIcon: 'delete',
  *       noEntriesFoundLabel: 'No options found'
@@ -37,9 +37,7 @@ export type ConfigurableGlobalOptions = typeof configurableGlobalOptions[number]
  *
  * See the corresponding inputs of `MatSelectSearchComponent` for documentation.
  */
-export const MATSELECTSEARCH_GLOBAL_OPTIONS = new InjectionToken<MatSelectSearchOptions>(
-  'global configuration options for ngx-mat-select-search'
-);
+export const MAT_SELECTSEARCH_DEFAULT_OPTIONS = new InjectionToken<MatSelectSearchOptions>('mat-selectsearch-default-options');
 
 /** Global configurable options for MatSelectSearch. */
-export type MatSelectSearchOptions = Readonly<Partial<Pick<MatSelectSearchComponent, ConfigurableGlobalOptions>>>;
+export type MatSelectSearchOptions = Readonly<Partial<Pick<MatSelectSearchComponent, ConfigurableDefaultOptions>>>;

--- a/src/app/mat-select-search/mat-select-search.component.spec.ts
+++ b/src/app/mat-select-search/mat-select-search.component.spec.ts
@@ -21,7 +21,7 @@ import { MatSelectSearchComponent } from './mat-select-search.component';
 import { NgxMatSelectSearchModule } from './ngx-mat-select-search.module';
 import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { DOWN_ARROW } from '@angular/cdk/keycodes';
-import { MATSELECTSEARCH_GLOBAL_OPTIONS, MatSelectSearchOptions } from './global-options';
+import { MAT_SELECTSEARCH_DEFAULT_OPTIONS, MatSelectSearchOptions } from './default-options';
 
 /* tslint:disable:component-selector */
 
@@ -712,7 +712,7 @@ describe('MatSelectSearchComponent', () => {
 });
 
 
-describe('MatSelectSearchComponent with global options', () => {
+describe('MatSelectSearchComponent with default options', () => {
   let component: MatSelectSearchTestComponent;
   let fixture: ComponentFixture<MatSelectSearchTestComponent>;
 
@@ -735,7 +735,7 @@ describe('MatSelectSearchComponent with global options', () => {
           }
         },
         {
-          provide: MATSELECTSEARCH_GLOBAL_OPTIONS,
+          provide: MAT_SELECTSEARCH_DEFAULT_OPTIONS,
           useValue: <MatSelectSearchOptions>{
             placeholderLabel: 'Mega bla',
           },

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -34,7 +34,7 @@ import { MatSelect } from '@angular/material/select';
 import { BehaviorSubject, combineLatest, Observable, of, Subject } from 'rxjs';
 import { delay, filter, map, startWith, switchMap, take, takeUntil, tap } from 'rxjs/operators';
 import { MatSelectSearchClearDirective } from './mat-select-search-clear.directive';
-import { configurableGlobalOptions, MATSELECTSEARCH_GLOBAL_OPTIONS, MatSelectSearchOptions } from './global-options';
+import { configurableDefaultOptions, MAT_SELECTSEARCH_DEFAULT_OPTIONS, MatSelectSearchOptions } from './default-options';
 
 
 /** The max height of the select's overlay panel. */
@@ -278,18 +278,18 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, ControlValue
     @Optional() @Inject(MatOption) public matOption: MatOption = null,
     private liveAnnouncer: LiveAnnouncer,
     @Optional() @Inject(MatFormField) public matFormField: MatFormField = null,
-    @Optional() @Inject(MATSELECTSEARCH_GLOBAL_OPTIONS) globalOptions?: MatSelectSearchOptions
+    @Optional() @Inject(MAT_SELECTSEARCH_DEFAULT_OPTIONS) defaultOptions?: MatSelectSearchOptions
   ) {
-    this.applyGlobalOptions(globalOptions);
+    this.applyDefaultOptions(defaultOptions);
   }
 
-  private applyGlobalOptions(globalOptions: MatSelectSearchOptions) {
-    if (!globalOptions) {
+  private applyDefaultOptions(defaultOptions: MatSelectSearchOptions) {
+    if (!defaultOptions) {
       return;
     }
-    for (let key of configurableGlobalOptions) {
-      if (globalOptions.hasOwnProperty(key)) {
-        (this[key] as any) = globalOptions[key];
+    for (let key of configurableDefaultOptions) {
+      if (defaultOptions.hasOwnProperty(key)) {
+        (this[key] as any) = defaultOptions[key];
       }
     }
   }

--- a/src/app/mat-select-search/public_api.ts
+++ b/src/app/mat-select-search/public_api.ts
@@ -1,3 +1,3 @@
 export * from './mat-select-search.component';
 export * from './ngx-mat-select-search.module';
-export * from './global-options';
+export * from './default-options';


### PR DESCRIPTION
Before this feature is getting used you could / should merge this PR. Fixed namings according to MatComponents. Sorry I named them wrong initially.