### PR TITLE
#266: rename misspelled input 

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Furthermore, it provides the following inputs:
   @Input() toggleAllCheckboxTooltipMessage = '';
 
   /** Define the position of the tooltip on the toggle-all checkbox. */
-  @Input() toogleAllCheckboxTooltipPosition: 'left' | 'right' | 'above' | 'below' | 'before' | 'after' = 'below';
+  @Input() toggleAllCheckboxTooltipPosition: 'left' | 'right' | 'above' | 'below' | 'before' | 'after' = 'below';
 
   /** Show/Hide the search clear button of the search input */
   @Input() hideClearSearchButton = false;
@@ -168,13 +168,6 @@ Furthermore, it provides the following inputs:
    * Defaults to false, so selected options are only restored while filtering is active. 
    */
   @Input() alwaysRestoreSelectedOptionsMulti = false;
-
-  /**
-  *  Text that is appended to the currently active item label announced by screen readers, informing the user of the current index, value and total
-  *  options.
-  *  eg: Bank R (Germany) 1 of 6
-  */
-  @Input() indexAndLengthScreenReaderText = ' of ';
   
   /** Output emitter to send to parent component with the toggle all boolean */
   @Output() toggleAll = new EventEmitter<boolean>();

--- a/src/app/examples/07-tooltip-select-all-example/tooltip-select-all-example.component.html
+++ b/src/app/examples/07-tooltip-select-all-example/tooltip-select-all-example.component.html
@@ -5,7 +5,7 @@
       <mat-option>
         <ngx-mat-select-search [showToggleAllCheckbox]="true" (toggleAll)="toggleSelectAll($event)"
           [formControl]="bankMultiFilterCtrl" [toggleAllCheckboxTooltipMessage]="tooltipMessage"
-          [toogleAllCheckboxTooltipPosition]="'above'"></ngx-mat-select-search>
+          [toggleAllCheckboxTooltipPosition]="'above'"></ngx-mat-select-search>
       </mat-option>
       <mat-option *ngFor="let bank of filteredBanksMulti | async" [value]="bank">
         {{bank.name}}

--- a/src/app/mat-select-search/mat-select-search.component.html
+++ b/src/app/mat-select-search/mat-select-search.component.html
@@ -14,7 +14,7 @@
                 [indeterminate]="toggleAllCheckboxIndeterminate"
                 [matTooltip]="toggleAllCheckboxTooltipMessage"
                 matTooltipClass="ngx-mat-select-search-toggle-all-tooltip"
-                [matTooltipPosition]="toogleAllCheckboxTooltipPosition"
+                [matTooltipPosition]="toggleAllCheckboxTooltipPosition"
                 (change)="_emitSelectAllBooleanToParent($event.checked)"
   ></mat-checkbox>
 

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -189,7 +189,7 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, ControlValue
   @Input() toggleAllCheckboxTooltipMessage = '';
 
   /** Define the position of the tooltip on the toggle-all checkbox. */
-  @Input() toogleAllCheckboxTooltipPosition: 'left' | 'right' | 'above' | 'below' | 'before' | 'after' = 'below';
+  @Input() toggleAllCheckboxTooltipPosition: 'left' | 'right' | 'above' | 'below' | 'before' | 'after' = 'below';
 
   /** Show/Hide the search clear button of the search input */
   @Input() hideClearSearchButton = false;


### PR DESCRIPTION
toogleAllCheckboxTooltipPosition to toggleAllCheckboxTooltipPosition

fixes #266