### PR TITLE
fix(examples): fix tooltip select all example

### DIFF
--- a/src/app/examples/07-tooltip-select-all-example/tooltip-select-all-example.component.ts
+++ b/src/app/examples/07-tooltip-select-all-example/tooltip-select-all-example.component.ts
@@ -60,10 +60,11 @@ export class TooltipSelectAllExampleComponent implements OnInit, AfterViewInit, 
   }
 
   toggleSelectAll(selectAllValue: boolean) {
-    this.filteredBanksMulti.pipe(take(1), takeUntil(this._onDestroy))
-      .subscribe(val => {
+    this.filteredBanksMulti
+      .pipe(take(1), takeUntil(this._onDestroy))
+      .subscribe(() => {
         if (selectAllValue) {
-          this.bankMultiCtrl.patchValue(val);
+          this.bankMultiCtrl.patchValue([...this.banks]);
         } else {
           this.bankMultiCtrl.patchValue([]);
         }


### PR DESCRIPTION
Fixed the case when you apply a filter and then click SELECT ALL previously, it used to tick mark select all but with only selecting the filtered items now it selects all items when we click SELECT ALL

Fixes #336