### PR TITLE
Fix issue with setting the first active item

### DIFF
--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -355,7 +355,7 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, ControlValue
                 if (firstOptionIsChanged
                   || !keyManager.activeItem
                   || !options.find(option => this.matSelect.compareWith(option, keyManager.activeItem))) {
-                  keyManager.setFirstItemActive();
+                  keyManager.setActiveItem(this.getOptionsLengthOffset());
                 }
 
                 // wait for panel width changes


### PR DESCRIPTION
Calling `keyManager.setFirstItemActive` doesn't take into account the mat-option surrounding the ngx-mat-select-search component, and causes that option to be selected when the options change, rather than the next mat-option. 