### PR TITLE
#512: Angular 19: Standalone defaults to true

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { MatSelectSearchVersion } from './mat-select-search/ngx-mat-select-searc
 
 @Component({
   selector: 'app-root',
+  standalone: false,
   templateUrl: 'app.component.html',
   styleUrls: ['app.component.scss']
 })

--- a/src/app/examples/01-single-selection-example/single-selection-example.component.ts
+++ b/src/app/examples/01-single-selection-example/single-selection-example.component.ts
@@ -9,6 +9,7 @@ import { Bank, BANKS } from '../demo-data';
 
 @Component({
   selector: 'app-single-selection-example',
+  standalone: false,
   templateUrl: './single-selection-example.component.html',
   styleUrls: ['./single-selection-example.component.scss']
 })

--- a/src/app/examples/02-multiple-selection-example/multiple-selection-example.component.ts
+++ b/src/app/examples/02-multiple-selection-example/multiple-selection-example.component.ts
@@ -8,6 +8,7 @@ import { Bank, BANKS } from '../demo-data';
 
 @Component({
   selector: 'app-multiple-selection-example',
+  standalone: false,
   templateUrl: './multiple-selection-example.component.html',
   styleUrls: ['./multiple-selection-example.component.scss']
 })

--- a/src/app/examples/03-custom-clear-icon-example/custom-clear-icon-example.component.ts
+++ b/src/app/examples/03-custom-clear-icon-example/custom-clear-icon-example.component.ts
@@ -5,6 +5,7 @@ import { SingleSelectionExampleComponent } from '../01-single-selection-example/
 
 @Component({
   selector: 'app-custom-clear-icon-example',
+  standalone: false,
   templateUrl: './custom-clear-icon-example.component.html',
   styleUrls: ['./custom-clear-icon-example.component.scss']
 })

--- a/src/app/examples/04-option-groups-example/option-groups-example.component.ts
+++ b/src/app/examples/04-option-groups-example/option-groups-example.component.ts
@@ -8,6 +8,7 @@ import { Bank, BankGroup, BANKGROUPS } from '../demo-data';
 
 @Component({
   selector: 'app-option-groups-example',
+  standalone: false,
   templateUrl: './option-groups-example.component.html',
   styleUrls: ['./option-groups-example.component.scss']
 })

--- a/src/app/examples/05-server-side-search-example/server-side-search-example.component.ts
+++ b/src/app/examples/05-server-side-search-example/server-side-search-example.component.ts
@@ -8,6 +8,7 @@ import { Bank, BANKS } from '../demo-data';
 
 @Component({
   selector: 'app-server-side-search-example',
+  standalone: false,
   templateUrl: './server-side-search-example.component.html',
   styleUrls: ['./server-side-search-example.component.scss']
 })

--- a/src/app/examples/06-multiple-selection-select-all-example/multiple-selection-select-all-example.component.ts
+++ b/src/app/examples/06-multiple-selection-select-all-example/multiple-selection-select-all-example.component.ts
@@ -8,6 +8,7 @@ import { Bank, BANKS } from '../demo-data';
 
 @Component({
   selector: 'app-multiple-selection-select-all-example',
+  standalone: false,
   templateUrl: './multiple-selection-select-all-example.component.html',
   styleUrls: ['./multiple-selection-select-all-example.component.scss']
 })

--- a/src/app/examples/07-tooltip-select-all-example/tooltip-select-all-example.component.ts
+++ b/src/app/examples/07-tooltip-select-all-example/tooltip-select-all-example.component.ts
@@ -8,6 +8,7 @@ import { Bank, BANKS } from '../demo-data';
 
 @Component({
   selector: 'app-tooltip-select-all-example',
+  standalone: false,
   templateUrl: './tooltip-select-all-example.component.html',
   styleUrls: ['./tooltip-select-all-example.component.scss']
 })

--- a/src/app/examples/08-infinite-scroll-example/infinite-scroll-example.component.ts
+++ b/src/app/examples/08-infinite-scroll-example/infinite-scroll-example.component.ts
@@ -10,6 +10,7 @@ import { Bank } from '../demo-data';
  */
 @Component({
   selector: 'app-infinite-scroll-example',
+  standalone: false,
   templateUrl: './infinite-scroll-example.component.html',
   styleUrls: ['./infinite-scroll-example.component.scss']
 })

--- a/src/app/examples/09-custom-no-entries-found-example/custom-no-entries-found-example.component.ts
+++ b/src/app/examples/09-custom-no-entries-found-example/custom-no-entries-found-example.component.ts
@@ -7,6 +7,7 @@ import { take, takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'app-custom-no-entries-found-example',
+  standalone: false,
   templateUrl: './custom-no-entries-found-example.component.html',
   styleUrls: ['./custom-no-entries-found-example.component.scss']
 })

--- a/src/app/mat-select-search/mat-select-no-entries-found.directive.ts
+++ b/src/app/mat-select-search/mat-select-no-entries-found.directive.ts
@@ -10,6 +10,7 @@ import { Directive } from '@angular/core';
  * </ngx-mat-select-search>
  */
 @Directive({
-  selector: '[ngxMatSelectNoEntriesFound]'
+  selector: '[ngxMatSelectNoEntriesFound]',
+  standalone: false
 })
 export class MatSelectNoEntriesFoundDirective {}

--- a/src/app/mat-select-search/mat-select-search-clear.directive.ts
+++ b/src/app/mat-select-search/mat-select-search-clear.directive.ts
@@ -8,6 +8,7 @@ import { Directive } from '@angular/core';
  * </ngx-mat-select-search>
  */
 @Directive({
-    selector: '[ngxMatSelectSearchClear]'
+    selector: '[ngxMatSelectSearchClear]',
+    standalone: false
 })
 export class MatSelectSearchClearDirective {}

--- a/src/app/mat-select-search/mat-select-search.component.spec.ts
+++ b/src/app/mat-select-search/mat-select-search.component.spec.ts
@@ -33,6 +33,7 @@ interface Bank {
 
 @Component({
   selector: 'mat-select-search-test',
+  standalone: false,
   template: `
     <h3>Single selection</h3>
     <p>

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -114,6 +114,7 @@ import { MatSelectNoEntriesFoundDirective } from './mat-select-no-entries-found.
  */
 @Component({
   selector: 'ngx-mat-select-search',
+  standalone: false,
   templateUrl: './mat-select-search.component.html',
   styleUrls: ['./mat-select-search.component.scss'],
   providers: [


### PR DESCRIPTION
In Angular v19, the standalone default is set to true. Currently, components are implemented as module-based components. This commit explicitly adds 'standalone: false' to all components and directives.

fixes https://github.com/bithost-gmbh/ngx-mat-select-search/issues/512