### PR TITLE
Fix Mat select search on latest Angular Material 3

### DIFF
--- a/src/app/mat-select-search/mat-select-search.component.scss
+++ b/src/app/mat-select-search/mat-select-search.component.scss
@@ -30,7 +30,7 @@ $mat-select-panel-padding: 8px;
     TODO: implement proper theming (https://github.com/bithost-gmbh/ngx-mat-select-search/issues/34)
   */
   box-shadow: none;
-  background-color: var(--mat-select-panel-background-color);
+  background-color: var(--mat-sys-surface-container);
 
   &.mat-select-search-inner-multiple.mat-select-search-inner-toggle-all {
     .mat-select-search-inner-row {
@@ -48,7 +48,7 @@ $mat-select-panel-padding: 8px;
   font-size: inherit;
   color: currentColor;
   outline: none;
-  background-color: var(--mat-select-panel-background-color);
+  background-color: var(--mat-sys-surface-container);
   padding: 0 $clear-button-width + $mat-select-search-clear-x 0 16px;
   height: calc($mat-option-height - 1px);
   line-height: calc($mat-option-height - 1px);

--- a/src/app/mat-select-search/mat-select-search.component.scss
+++ b/src/app/mat-select-search/mat-select-search.component.scss
@@ -30,7 +30,8 @@ $mat-select-panel-padding: 8px;
     TODO: implement proper theming (https://github.com/bithost-gmbh/ngx-mat-select-search/issues/34)
   */
   box-shadow: none;
-  background-color: var(--mat-sys-surface-container);
+
+  background-color: var(--mat-sys-surface-container, var(--mat-select-panel-background-color, white));
 
   &.mat-select-search-inner-multiple.mat-select-search-inner-toggle-all {
     .mat-select-search-inner-row {
@@ -48,7 +49,7 @@ $mat-select-panel-padding: 8px;
   font-size: inherit;
   color: currentColor;
   outline: none;
-  background-color: var(--mat-sys-surface-container);
+  background-color: var(--mat-sys-surface-container, var(--mat-select-panel-background-color, white));
   padding: 0 $clear-button-width + $mat-select-search-clear-x 0 16px;
   height: calc($mat-option-height - 1px);
   line-height: calc($mat-option-height - 1px);


### PR DESCRIPTION
- Use the new SCSS variable `--mat-sys-surface-container` for setting the background. Just like https://material.angular.io/components/select/styling is also using the `--mat-sys-surface-container` variable for background color. 
- Implement fallback to `--mat-sys-surface-container`
- Finally, if both are not defined (for whatever reason), we fallback to just white. So we a least **have** no transparent background issue.

**Before:**

![image](https://github.com/user-attachments/assets/9e620816-6738-45e1-8109-df8f22d05ec9)

**After:**

![image](https://github.com/user-attachments/assets/b35b2eac-dd75-4ab6-af9b-1399eb3520c2)


Fixes: https://github.com/bithost-gmbh/ngx-mat-select-search/issues/542