### PR TITLE
fix(#594): allow Escape to bubble past the panel so mat-select can close

### DIFF
--- a/src/app/mat-select-search/mat-select-search.component.spec.ts
+++ b/src/app/mat-select-search/mat-select-search.component.spec.ts
@@ -498,6 +498,51 @@ describe('MatSelectSearchComponent', () => {
         });
     });
 
+    // Reproduces https://github.com/bithost-gmbh/ngx-mat-select-search/issues/594.
+    // The fix for #562 stopped propagation for *all* keydown events on the panel,
+    // including ESC. mat-select closes the panel on ESC via a body-level keydown
+    // dispatcher (CdkConnectedOverlay -> overlayKeydown -> _handleOverlayKeydown),
+    // so the ESC event must be allowed to bubble out of the panel to the body.
+    it('should allow Escape keydown to bubble past the select panel so mat-select can close', (done) => {
+      component.filteredBanks
+        .pipe(
+          take(1),
+          delay(1)
+        )
+        .subscribe(() => {
+          fixture.detectChanges();
+
+          component.matSelect.open();
+          fixture.detectChanges();
+
+          component.matSelect.openedChange
+            .pipe(
+              take(1),
+              delay(1)
+            )
+            .subscribe(() => {
+              const panel = component.matSelect.panel.nativeElement as HTMLElement;
+              expect(panel).toBeTruthy();
+
+              const ancestor = panel.parentElement as HTMLElement;
+              expect(ancestor).toBeTruthy();
+              const ancestorListener = jasmine.createSpy('ancestorKeydown');
+              ancestor.addEventListener('keydown', ancestorListener);
+
+              const event = new KeyboardEvent('keydown', {
+                key: 'Escape',
+                bubbles: true,
+                cancelable: true,
+              });
+              panel.dispatchEvent(event);
+
+              ancestor.removeEventListener('keydown', ancestorListener);
+              expect(ancestorListener).toHaveBeenCalled();
+              done();
+            });
+        });
+    });
+
     describe('inside mat-option', () => {
 
       it('should show a search field and focus it when opening the select', (done) => {

--- a/src/app/mat-select-search/mat-select-search.component.ts
+++ b/src/app/mat-select-search/mat-select-search.component.ts
@@ -491,6 +491,10 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, ControlValue
    * second time after the panel's template (keydown) already handled it — causing arrow
    * navigation to skip items and Enter to double-fire. We stop propagation at the panel
    * after its template handler runs, leaving popover behavior intact.
+   *
+   * Escape is intentionally excluded: mat-select closes the panel on Escape via the CDK
+   * overlay's body-level keydown dispatcher (overlayKeydown -> _handleOverlayKeydown), so
+   * the event must be allowed to bubble out of the panel. See #594.
    */
   private _installPanelKeydownListener() {
     this._removePanelKeydownListener?.();
@@ -502,6 +506,9 @@ export class MatSelectSearchComponent implements OnInit, OnDestroy, ControlValue
     }
 
     const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        return;
+      }
       event.stopPropagation();
     };
     panel.addEventListener('keydown', handler);


### PR DESCRIPTION
The fix for #562 (stopping panel keydown propagation to prevent double _handleKeydown under Angular Material v21's popover-inline topology) stopped propagation for *all* keys, including Escape. mat-select closes the panel on Escape via the CDK overlay's body-level keydown dispatcher (overlayKeydown -> _handleOverlayKeydown), so the event must reach the body to trigger close. Excluding Escape from stopPropagation restores the close-on-Escape behavior without reintroducing the duplicate-keydown problem (mat-select's host _handleKeydown ignores Escape).

Fixes #594 

Co-authored with Claude Code (Opus 4.7)